### PR TITLE
fix: add missing model_rebuild() for Pydantic forward references

### DIFF
--- a/database_utils/schemas/__init__.py
+++ b/database_utils/schemas/__init__.py
@@ -14,8 +14,17 @@ from .user import *
 
 # Rebuild models with forward references to resolve circular dependencies
 from .order import OrderOut
-from .recurring_order import RecurringOrderOut, OrderGenerationResponse
+from .recurring_order import (
+    RecurringOrderOut,
+    RecurringOrderCreateResponse,
+    OrderGenerationResponse,
+    GeneratedOrdersWithGaps,
+    RegeneratePeriodResponse,
+)
 
 OrderOut.model_rebuild()
 RecurringOrderOut.model_rebuild()
+RecurringOrderCreateResponse.model_rebuild()
 OrderGenerationResponse.model_rebuild()
+GeneratedOrdersWithGaps.model_rebuild()
+RegeneratePeriodResponse.model_rebuild()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.4.0
+version = 1.4.1
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)


### PR DESCRIPTION
RecurringOrderCreateResponse, GeneratedOrdersWithGaps, and RegeneratePeriodResponse all use OrderOut as a forward reference but were missing model_rebuild() calls, causing 500 errors when creating recurring orders.