### PR TITLE
feat(models-utils): add serialize_for_audit() and compute_pagination() utilities

### DIFF
--- a/database_utils/utils/audit_utils.py
+++ b/database_utils/utils/audit_utils.py
@@ -258,3 +258,31 @@ def log_custom_operation(
         details=details,
         ip_address=ip_address
     )
+
+
+def serialize_for_audit(data: dict) -> dict:
+    """Convert a model column dict to JSON-safe types for audit logging.
+
+    Handles UUID, datetime, date, and Decimal types that are not
+    JSON-serializable by default.
+
+    Args:
+        data: Dictionary of model column values to serialize.
+
+    Returns:
+        A new dictionary with all non-JSON-serializable values converted to str.
+    """
+    from uuid import UUID
+    from datetime import datetime, date
+    from decimal import Decimal
+
+    def _convert(v):
+        if isinstance(v, (UUID, datetime, date, Decimal)):
+            return str(v)
+        if isinstance(v, dict):
+            return {k: _convert(val) for k, val in v.items()}
+        if isinstance(v, list):
+            return [_convert(item) for item in v]
+        return v
+
+    return {k: _convert(v) for k, v in data.items()}

--- a/database_utils/utils/pagination_utils.py
+++ b/database_utils/utils/pagination_utils.py
@@ -1,0 +1,20 @@
+import math
+
+
+def compute_pagination(page: int, page_size: int, total_count: int) -> tuple[int, int, int]:
+    """Compute pagination values for a SQLAlchemy query.
+
+    Args:
+        page: Current page number (1-indexed).
+        page_size: Number of records per page.
+        total_count: Total number of records matching the query filters.
+
+    Returns:
+        tuple: (skip, total_count, total_pages)
+            - skip: number of records to offset
+            - total_count: same as input (passed through for convenience)
+            - total_pages: total number of pages (minimum 1)
+    """
+    skip = (page - 1) * page_size
+    total_pages = math.ceil(total_count / page_size) if total_count > 0 else 1
+    return skip, total_count, total_pages


### PR DESCRIPTION
## Summary
- Add `serialize_for_audit(data: dict) -> dict` to `audit_utils.py` — recursively converts UUID, datetime, date, and Decimal to strings for JSON-safe audit logging. Replaces 9 duplicated inline dict comprehensions across backend-erp. Also fixes a correctness gap: the inline comprehensions only handled UUID, but datetime/Decimal would silently fail at serialization time.
- Add new `pagination_utils.py` with `compute_pagination(page, page_size, total_count) -> tuple[int, int, int]` — centralizes the repeated skip/total_pages arithmetic from clients, orders, and products list endpoints.

## Test plan
- [ ] `compute_pagination(2, 10, 25)` returns `(10, 25, 3)`
- [ ] `serialize_for_audit({'id': UUID(...), 'created_at': datetime(...)})` returns `{'id': '<str>', 'created_at': '<str>'}`
- [ ] Both files pass `py_compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)