### PR TITLE
feat: Integrations model + HTTP_REQUEST workflow step type

### DIFF
--- a/alembic/seeds/rbac_seed.py
+++ b/alembic/seeds/rbac_seed.py
@@ -121,6 +121,12 @@ def seed_rbac_data(connection: Connection) -> None:
             {"name": "task_states.read", "resource": "task_states", "action": "read", "description": "View task states/columns"},
             {"name": "task_states.update", "resource": "task_states", "action": "update", "description": "Update task states/columns"},
             {"name": "task_states.delete", "resource": "task_states", "action": "delete", "description": "Delete task states/columns"},
+
+            # Integration permissions
+            {"name": "integrations.create", "resource": "integrations", "action": "create", "description": "Create external API integrations"},
+            {"name": "integrations.read", "resource": "integrations", "action": "read", "description": "View external API integrations"},
+            {"name": "integrations.update", "resource": "integrations", "action": "update", "description": "Update external API integrations"},
+            {"name": "integrations.delete", "resource": "integrations", "action": "delete", "description": "Delete external API integrations"},
         ]
 
         for perm in permissions_data:

--- a/alembic/versions/c865c4c8e97a_add_integration_table_and_http_request_.py
+++ b/alembic/versions/c865c4c8e97a_add_integration_table_and_http_request_.py
@@ -1,0 +1,48 @@
+"""add_integration_table_and_http_request_step_type
+
+Revision ID: c865c4c8e97a
+Revises: a2f968506210
+Create Date: 2026-02-23 11:15:32.785448
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c865c4c8e97a'
+down_revision: Union[str, Sequence[str], None] = 'a2f968506210'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Create the integration table (with its own IntegrationAuthType enum)
+    op.create_table('integration',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('name', sa.String(), nullable=False),
+    sa.Column('description', sa.String(), nullable=True),
+    sa.Column('base_url', sa.String(), nullable=False),
+    sa.Column('auth_type', sa.Enum('NONE', 'API_KEY', 'BEARER_TOKEN', 'BASIC_AUTH', name='integrationauthtype'), nullable=False),
+    sa.Column('credentials', sa.JSON(), nullable=True),
+    sa.Column('company_id', sa.Uuid(), nullable=False),
+    sa.ForeignKeyConstraint(['company_id'], ['company.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+    # 2. Add HTTP_REQUEST to the stepactiontype enum (PostgreSQL ALTER TYPE)
+    op.execute("ALTER TYPE stepactiontype ADD VALUE IF NOT EXISTS 'HTTP_REQUEST'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop the integration table (and its enum)
+    op.drop_table('integration')
+    op.execute("DROP TYPE IF EXISTS integrationauthtype")
+    # NOTE: PostgreSQL does not support removing enum values;
+    # HTTP_REQUEST in stepactiontype cannot be automatically rolled back.

--- a/alembic/versions/d4e5f6a7b8c9_add_integrations_permissions.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_integrations_permissions.py
@@ -1,0 +1,81 @@
+"""add_integrations_permissions
+
+Revision ID: d4e5f6a7b8c9
+Revises: c865c4c8e97a
+Create Date: 2026-02-24 21:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, Sequence[str], None] = 'c865c4c8e97a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_PERMISSIONS = [
+    ('integrations.create', 'integrations', 'create', 'Create external API integrations'),
+    ('integrations.read',   'integrations', 'read',   'View external API integrations'),
+    ('integrations.update', 'integrations', 'update', 'Update external API integrations'),
+    ('integrations.delete', 'integrations', 'delete', 'Delete external API integrations'),
+]
+
+
+def upgrade() -> None:
+    """Insert integrations.* permissions and assign to ADMIN and MANAGER roles."""
+    connection = op.get_bind()
+
+    # Insert the four new permissions (idempotent)
+    for name, resource, action, description in _PERMISSIONS:
+        connection.execute(
+            text(
+                """
+                INSERT INTO permission (id, created_at, name, resource, action, description)
+                VALUES (gen_random_uuid(), NOW(), :name, :resource, :action, :description)
+                ON CONFLICT (name) DO NOTHING
+                """
+            ),
+            {'name': name, 'resource': resource, 'action': action, 'description': description},
+        )
+
+    # Assign all four permissions to ADMIN and MANAGER roles (idempotent)
+    for role_name in ('ADMIN', 'MANAGER'):
+        for perm_name, _, _, _ in _PERMISSIONS:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO role_permission (role_id, permission_id)
+                    SELECT r.id, p.id
+                    FROM role r, permission p
+                    WHERE r.name = :role_name AND p.name = :perm_name
+                    ON CONFLICT DO NOTHING
+                    """
+                ),
+                {'role_name': role_name, 'perm_name': perm_name},
+            )
+
+
+def downgrade() -> None:
+    """Remove integrations.* permissions."""
+    connection = op.get_bind()
+
+    # Remove role_permission associations first
+    for name, _, _, _ in _PERMISSIONS:
+        connection.execute(
+            text(
+                "DELETE FROM role_permission WHERE permission_id = (SELECT id FROM permission WHERE name = :name)"
+            ),
+            {'name': name},
+        )
+
+    # Remove the permissions
+    for name, _, _, _ in _PERMISSIONS:
+        connection.execute(
+            text("DELETE FROM permission WHERE name = :name"),
+            {'name': name},
+        )

--- a/database_utils/models/__init__.py
+++ b/database_utils/models/__init__.py
@@ -17,6 +17,8 @@ from .crm import (
     TaskStateColor,
     Task,
     task_assignee,
+    Integration,
+    IntegrationAuthType,
 )
 
 from .workflow import (
@@ -51,6 +53,8 @@ __all__ = [
     "TaskStateColor",
     "Task",
     "task_assignee",
+    "Integration",
+    "IntegrationAuthType",
     # Workflows
     "Workflow",
     "WorkflowTrigger",

--- a/database_utils/models/auth.py
+++ b/database_utils/models/auth.py
@@ -83,6 +83,7 @@ class Company(Base):
     tasks = relationship("Task", back_populates="company", cascade="all, delete-orphan")
     task_templates = relationship("TaskTemplate", back_populates="company", cascade="all, delete-orphan")
     workflows = relationship("Workflow", back_populates="company", cascade="all, delete-orphan")
+    integrations = relationship("Integration", back_populates="company", cascade="all, delete-orphan")
     roles = relationship("Role", back_populates="company", cascade="all, delete-orphan")
 
 

--- a/database_utils/models/crm.py
+++ b/database_utils/models/crm.py
@@ -295,3 +295,34 @@ class TaskTemplate(Base):
     # Relationships
     company = relationship("Company", back_populates="task_templates")
     creator = relationship("User", foreign_keys=[created_by])
+
+
+class IntegrationAuthType(str, enum.Enum):
+    NONE = "NONE"
+    API_KEY = "API_KEY"
+    BEARER_TOKEN = "BEARER_TOKEN"
+    BASIC_AUTH = "BASIC_AUTH"
+
+
+class Integration(Base):
+    __tablename__ = "integration"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=now_gt)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=now_gt, onupdate=now_gt)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    base_url = Column(String, nullable=False)
+    auth_type = Column(Enum(IntegrationAuthType), nullable=False, default=IntegrationAuthType.NONE)
+    credentials = Column(JSON, nullable=True)
+    # Credentials format per auth_type:
+    # API_KEY:       {"header_name": "X-API-Key", "api_key": "sk-..."}
+    # BEARER_TOKEN:  {"token": "eyJ..."}
+    # BASIC_AUTH:    {"username": "admin", "password": "..."}
+
+    company_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # Relationships
+    company = relationship("Company", back_populates="integrations")

--- a/database_utils/models/workflow.py
+++ b/database_utils/models/workflow.py
@@ -25,6 +25,7 @@ class TriggerEventType(str, enum.Enum):
 class StepActionType(str, enum.Enum):
     UPDATE_FIELD = "UPDATE_FIELD"
     CREATE_ENTITY = "CREATE_ENTITY"
+    HTTP_REQUEST = "HTTP_REQUEST"
 
 
 class ExecutionStatus(str, enum.Enum):

--- a/database_utils/schemas/__init__.py
+++ b/database_utils/schemas/__init__.py
@@ -15,6 +15,7 @@ from .task_state import *
 from .task_template import *
 from .user import *
 from .workflow import *
+from .integration import *
 
 # Rebuild models with forward references to resolve circular dependencies
 from .order import OrderOut

--- a/database_utils/schemas/integration.py
+++ b/database_utils/schemas/integration.py
@@ -1,0 +1,50 @@
+from pydantic import BaseModel, ConfigDict
+from typing import Optional, Dict, Any
+from uuid import UUID
+from datetime import datetime
+
+from database_utils.models.crm import IntegrationAuthType
+
+MASKED = "***"
+SENSITIVE_KEYS = {"api_key", "token", "password"}
+
+
+class IntegrationCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    base_url: str
+    auth_type: IntegrationAuthType = IntegrationAuthType.NONE
+    credentials: Optional[Dict[str, Any]] = None
+
+
+class IntegrationUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    base_url: Optional[str] = None
+    auth_type: Optional[IntegrationAuthType] = None
+    credentials: Optional[Dict[str, Any]] = None
+
+
+class IntegrationOut(BaseModel):
+    id: UUID
+    company_id: UUID
+    name: str
+    description: Optional[str] = None
+    base_url: str
+    auth_type: IntegrationAuthType
+    credentials: Optional[Dict[str, Any]] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_orm_masked(cls, obj) -> "IntegrationOut":
+        """Return an IntegrationOut with sensitive credential values replaced by ***."""
+        instance = cls.model_validate(obj)
+        if instance.credentials:
+            instance.credentials = {
+                k: MASKED if k in SENSITIVE_KEYS else v
+                for k, v in instance.credentials.items()
+            }
+        return instance


### PR DESCRIPTION
## Summary

- **New `Integration` model** (`integration` table) — company-scoped registry of external API connections. Stores `name`, `base_url`, `auth_type` (NONE / API_KEY / BEARER_TOKEN / BASIC_AUTH), and `credentials` JSON.
- **New `IntegrationAuthType` enum** for the four supported auth strategies.
- **`HTTP_REQUEST` added to `StepActionType`** — enables workflow steps to call external APIs.
- **`Company.integrations` back-reference** added to the Company relationship chain (CASCADE delete).
- **`IntegrationCreate/Update/Out` Pydantic schemas** — `IntegrationOut.from_orm_masked()` redacts `api_key`, `token`, and `password` values in GET responses.
- **`_resolve_template()`** — recursively resolves `{{trigger.resource_id}}`, `{{trigger.after.FIELD}}`, and `{{steps.UUID.FIELD}}` in HTTP request bodies and headers.
- **`_execute_http_request()`** added to workflow engine — lazy-imports `httpx` (lives in backend-erp) and `Integration`; applies auth headers per `auth_type`; stores `status_code`, `response_body` (≤10KB), and `success` in `WorkflowStepExecution.result`.
- **Alembic migration** `c865c4c8e97a` — creates `integration` table with `integrationauthtype` enum, and runs `ALTER TYPE stepactiontype ADD VALUE IF NOT EXISTS 'HTTP_REQUEST'`.

## Test plan

- [ ] GitHub Actions migration runs successfully against dev DB
- [ ] `integration` table and `integrationauthtype` enum exist in dev DB
- [ ] `stepactiontype` enum includes `HTTP_REQUEST` value
- [ ] `IntegrationOut.from_orm_masked()` returns `***` for sensitive credential keys
- [ ] `_resolve_template()` correctly resolves nested `{{trigger.after.field}}` and `{{steps.UUID.field}}` patterns
- [ ] Workflow engine executes `HTTP_REQUEST` step and stores result in `WorkflowStepExecution.result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)