### PR TITLE
Release: db-sanity-fixes (models-utils)

### DIFF
--- a/alembic/versions/f9a8f43a1cbb_add_unique_index_on_order_recurring_.py
+++ b/alembic/versions/f9a8f43a1cbb_add_unique_index_on_order_recurring_.py
@@ -1,0 +1,72 @@
+"""add unique index on order recurring_order_id due_date
+
+Revision ID: f9a8f43a1cbb
+Revises: 090ee4ba0ead
+Create Date: 2026-05-05 00:49:12.580494
+
+Cleans up duplicate recurring-order generations and enforces uniqueness at the
+DB layer. The race in RecurringOrderService.generate_order_from_template
+(read-then-write without SELECT FOR UPDATE) allowed two concurrent cron runs
+to generate two non-cancelled orders for the same (recurring_order_id, due_date).
+
+Cleanup rule: within each (recurring_order_id, due_date) group, keep one
+non-cancelled order. Prefer paid orders; among unpaid, keep the oldest. Cancel
+the rest. If two or more orders are paid for the same period, leave them all
+non-cancelled (manual review required) — the partial unique index creation
+will fail in that case, which is the correct outcome.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f9a8f43a1cbb'
+down_revision: Union[str, Sequence[str], None] = '090ee4ba0ead'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Cancel newer unpaid duplicates per (recurring_order_id, due_date).
+    op.execute(
+        """
+        UPDATE "order"
+        SET status = 'CANCELLED'
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY recurring_order_id, due_date
+                        ORDER BY paid DESC, created_at ASC
+                    ) AS rn
+                FROM "order"
+                WHERE recurring_order_id IS NOT NULL
+                  AND status != 'CANCELLED'
+            ) ranked
+            WHERE rn > 1 AND id IN (
+                SELECT id FROM "order" WHERE paid = false
+            )
+        )
+        """
+    )
+
+    # 2. Partial unique index. Excludes CANCELLED so historical cancellations
+    #    do not collide with new generations for the same period.
+    op.create_index(
+        "uq_order_active_recurring_due_date",
+        "order",
+        ["recurring_order_id", "due_date"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status != 'CANCELLED' AND recurring_order_id IS NOT NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("uq_order_active_recurring_due_date", table_name="order")

--- a/database_utils/models/crm.py
+++ b/database_utils/models/crm.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (
-    Column, String, Integer, Boolean, JSON, DateTime, ForeignKey, Enum, text, Uuid, Float, Table
+    Column, String, Integer, Boolean, JSON, DateTime, ForeignKey, Enum, text, Uuid, Float, Table, Index
 )
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
@@ -163,6 +163,18 @@ class Order(Base):
     invoices = relationship("Invoice", back_populates="order", cascade="all, delete-orphan")
     order_items = relationship("OrderItem", back_populates="order", cascade="all, delete-orphan")
     recurring_order = relationship("RecurringOrder", back_populates="generated_orders")
+
+    # Partial unique index: at most one non-cancelled order per (recurring_order_id, due_date).
+    # Prevents the duplicate-generation race in RecurringOrderService.generate_order_from_template.
+    __table_args__ = (
+        Index(
+            "uq_order_active_recurring_due_date",
+            "recurring_order_id",
+            "due_date",
+            unique=True,
+            postgresql_where=text("status != 'CANCELLED' AND recurring_order_id IS NOT NULL"),
+        ),
+    )
 
 
 class OrderItem(Base):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.4.4
+version = 1.4.5
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)


### PR DESCRIPTION
## Summary
Promotes db-sanity-fixes to production:
- Cancels duplicate recurring-order generations per `(recurring_order_id, due_date)` (preserves history)
- Adds partial unique index `uq_order_active_recurring_due_date WHERE status != 'CANCELLED' AND recurring_order_id IS NOT NULL`
- Bumps version `1.4.4 → 1.4.5`

GitHub Actions migrate.yml runs `alembic upgrade head` against prod on merge.

## Test plan
- [x] Verified on dev: index created, dupes cancelled (618 of 627)
- [ ] Confirm migrate.yml runs successfully on merge
- [ ] Re-run db-sanity-check vs prod after backend deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)