### PR TITLE
fix: make RBAC permission seed idempotent against migration-inserted rows

### DIFF
--- a/alembic/seeds/rbac_seed.py
+++ b/alembic/seeds/rbac_seed.py
@@ -133,7 +133,12 @@ def seed_rbac_data(connection: Connection) -> None:
             connection.execute(
                 text(
                     "INSERT INTO permission (id, created_at, name, resource, action, description) "
-                    "VALUES (gen_random_uuid(), :created_at, :name, :resource, :action, :description)"
+                    "VALUES (gen_random_uuid(), :created_at, :name, :resource, :action, :description) "
+                    # Some permissions are also inserted by individual migrations
+                    # (e.g. orders.change_status, integrations.*). On a from-scratch
+                    # DB the seed runs while `role` is still empty, so it must not
+                    # collide with those migration-inserted rows.
+                    "ON CONFLICT (name) DO NOTHING"
                 ),
                 {
                     'created_at': now_gt(),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.4.5
+version = 1.4.6
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)


### PR DESCRIPTION
## Summary

`seed_rbac_data()` claims idempotency in its docstring, but its guard only checks the `role` table. Several migrations pre-insert **permissions**:
- `9e6f5200dac4` → `orders.change_status`
- `d4e5f6a7b8c9` → `integrations.*`

On a **from-scratch** alembic run the seed proceeds (because `role` is still empty) and its plain `INSERT` collides with those migration-inserted permission rows:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation)
duplicate key value violates unique constraint "permission_name_key"
DETAIL:  Key (name)=(orders.change_status) already exists.
```

Because the seed runs inside the same `context.begin_transaction()` as the migrations (see `alembic/env.py`), the failure **rolls back the entire migration** — the DB ends up empty.

## Fix

Add `ON CONFLICT (name) DO NOTHING` to the permission insert so the seed is actually idempotent, matching its documented contract. Role / role_permission / user_role inserts are unchanged (already short-circuited by the `role`-count guard). Bumped `version` 1.4.5 → 1.4.6.

## Why it surfaced now

The new local docker compose stack runs the `migrate` service (`alembic upgrade head`) against an **empty** database. The Railway dev DB predated those permission migrations, so the from-scratch path was never exercised before. This also protects a fresh production bootstrap.

## Verification

After the fix, `migrate` runs the full revision chain (`f612571eaad0` → `f9a8f43a1cbb`) + RBAC/tier seed and exits 0; loading production data on top works.

## Scope

Seed-only change. The `alembic/` tree is **not** part of the installed `database_utils` package (`packages=find: include database_utils*`), so `backend-erp` / `auth-erp` runtime is unaffected and no backend dependency re-pin is required. Production migration runs via GitHub Actions on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)