### PR TITLE
release: local docker dev env + RBAC seed idempotency fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.git/
+alembic/__pycache__/

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,45 +1,19 @@
 name: Alembic Migrate
 
+# Development DB is now LOCAL (docker compose `migrate` service) — there is no
+# remote dev migration job anymore. This workflow only migrates PRODUCTION on
+# merge to `main`. The Railway development environment was decommissioned.
+
 on:
-  pull_request:
-    branches:
-      - develop
-    paths:
-      - "alembic/versions/**"
   push:
     branches:
-      - develop
       - main
     paths:
       - "alembic/versions/**"
 
 jobs:
-  migrate-dev:
-    name: Migrate development database
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
-    runs-on: ubuntu-latest
-    environment: development
-    env:
-      DB_URL: ${{ secrets.DB_URL }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-
-      - name: Apply migrations (development)
-        run: alembic upgrade head
-
   migrate-prod:
     name: Migrate production database
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ Uses the same feature branch + PR model as all other services. **Never push dire
 
 Branch naming: `{type}/{feature-id}/models-{description}` (e.g. `feat/tier-billing/models-subscription`)
 
-GitHub Actions runs `alembic upgrade head` automatically:
-- On PR open/push to `develop` → migrates **development** database
-- On merge to `main` → migrates **production** database
+Database migrations:
+- **Development** is the LOCAL docker compose DB — the `migrate` compose service runs `alembic upgrade head` on every `docker compose up` (Railway dev was decommissioned)
+- **Production**: GitHub Actions runs `alembic upgrade head` automatically on merge to `main`
 
 ## Migration Workflow (Alembic)
 
@@ -31,9 +31,9 @@ Correct order:
 2. Edit model + schema + bump version in `pyproject.toml`
 3. Generate revision: `alembic revision --autogenerate -m "description"`
 4. Commit and push feature branch
-5. Open PR to `develop` — GitHub Actions migrates dev DB
+5. Compose into `develop` (erp-release); the local `migrate` compose service applies the revision on `docker compose up`
 6. Pin consuming services (`backend-erp`, `auth-erp`) to the feature branch SHA
-7. After E2E passes, merge PR to `main` — GitHub Actions migrates prod DB
+7. After E2E passes locally, merge PR to `main` — GitHub Actions migrates prod DB
 
 ## After Changing Models (local dev)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Local development image for models-utils Alembic migrations.
+# Used by the docker-compose `migrate` one-shot service to bring the local
+# Postgres up to head before the backends start.
+# Production/dev DB migrations on Railway run via GitHub Actions, not this file.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the package (pulls SQLAlchemy, Alembic, psycopg2, etc.) plus the
+# working-tree source which carries the alembic/ migration scripts.
+COPY . .
+RUN pip install --no-cache-dir .
+
+# alembic.ini lives at the repo root; DB_URL is injected by docker-compose.
+CMD ["alembic", "upgrade", "head"]

--- a/alembic/seeds/rbac_seed.py
+++ b/alembic/seeds/rbac_seed.py
@@ -133,7 +133,12 @@ def seed_rbac_data(connection: Connection) -> None:
             connection.execute(
                 text(
                     "INSERT INTO permission (id, created_at, name, resource, action, description) "
-                    "VALUES (gen_random_uuid(), :created_at, :name, :resource, :action, :description)"
+                    "VALUES (gen_random_uuid(), :created_at, :name, :resource, :action, :description) "
+                    # Some permissions are also inserted by individual migrations
+                    # (e.g. orders.change_status, integrations.*). On a from-scratch
+                    # DB the seed runs while `role` is still empty, so it must not
+                    # collide with those migration-inserted rows.
+                    "ON CONFLICT (name) DO NOTHING"
                 ),
                 {
                     'created_at': now_gt(),

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -11,15 +11,16 @@ Located in `alembic/versions/` — each file is an auto-generated Alembic revisi
 
 ## Connections to Other Components
 - **auth-erp** and **backend-erp**: Both share the same PostgreSQL database; migrations apply to both
-- **GitHub Actions**: Automatically runs `alembic upgrade head` on dev DB when PR to `develop` is opened; on prod DB when merged to `main`
-- **Feature branches**: Schema changes committed to feature branch in models-utils; PR to develop triggers migration
+- **Local development**: the `migrate` service in the root `docker-compose.yml` runs `alembic upgrade head` against the local DB on every `docker compose up` (Railway dev was decommissioned)
+- **GitHub Actions**: Runs `alembic upgrade head` on the **production** DB when merged to `main`
+- **Feature branches**: Schema changes committed to a feature branch in models-utils, then composed into `develop`
 
 ## Key Implementation Details
 - Migration workflow:
   1. Modify model in `database_utils/models/`
   2. Run `alembic revision --autogenerate -m "description"` to generate revision file
   3. Review generated file for correctness
-  4. Commit to feature branch; GitHub Actions applies on push to develop/main
+  4. Commit to feature branch; the local `migrate` service applies it on `docker compose up`, and GitHub Actions applies it to prod on merge to `main`
 - `alembic.ini`: configured to use `POSTGRES_*` env vars for connection string
 - All migrations are reversible (downgrade functions implemented)
 - Additive changes (new columns, new tables): safe to apply before consuming service code

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.4.5
+version = 1.4.6
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)


### PR DESCRIPTION
Promote to production. Carries two merged features:

- **RBAC seed idempotency** (#25) — `ON CONFLICT (name) DO NOTHING` so a from-scratch `alembic upgrade head` doesn't collide with migration-inserted permissions. Protects fresh prod bootstrap.
- **Local docker dev env** (#26) — Dockerfile for the compose `migrate` service; `migrate.yml` drops the dead `migrate-dev` job (Railway dev decommissioned); docs updated.

No `alembic/versions/**` changes, so the `migrate-prod` GitHub Actions job does **not** fire on this merge — prod DB schema is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)