### PR TITLE
Release: CI pipeline + permission_dependency UUID fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,13 @@ jobs:
         run: ruff check .
         continue-on-error: true
       - name: Tests
+        env:
+          # database_utils.database builds the engine from these at import
+          # (lazy connect); tests use an in-memory SQLite session, so these
+          # are placeholders just to satisfy the import-time config check.
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: test
         run: pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest ruff
+      - name: Lint (advisory)
+        run: ruff check .
+        continue-on-error: true
+      - name: Tests
+        run: pytest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Local development image for models-utils Alembic migrations.
 # Used by the docker-compose `migrate` one-shot service to bring the local
 # Postgres up to head before the backends start.
@@ -12,8 +13,12 @@ RUN apt-get update \
 
 # Install the package (pulls SQLAlchemy, Alembic, psycopg2, etc.) plus the
 # working-tree source which carries the alembic/ migration scripts.
+# BuildKit cache mount: even when source changes bust this layer, pip reuses
+# the cached downloads/wheels (shared with backend-erp/auth-erp) instead of
+# re-fetching the whole dependency tree.
 COPY . .
-RUN pip install --no-cache-dir .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install .
 
 # alembic.ini lives at the repo root; DB_URL is injected by docker-compose.
 CMD ["alembic", "upgrade", "head"]

--- a/database_utils/utils/permission_utils.py
+++ b/database_utils/utils/permission_utils.py
@@ -135,6 +135,19 @@ def require_permission(permission_name: str, get_db_func):
                 detail="Invalid token payload"
             )
 
+        # The JWT carries the user id as a string, but User.id is a SQLAlchemy
+        # Uuid column whose bind processor expects a uuid.UUID. Postgres tolerates
+        # the string via the driver; SQLite does not (raises "'str' object has no
+        # attribute 'hex'"). Coerce explicitly so the query works on both dialects.
+        if isinstance(user_id, str):
+            try:
+                user_id = UUID(user_id)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid token payload"
+                )
+
         # Get user with permissions
         user = PermissionChecker.get_user_by_id_with_roles(db, user_id)
         logger.info(f"[permission_dependency] {user = }")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.4.4
+version = 1.4.7
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)

--- a/tests/test_permission_uuid.py
+++ b/tests/test_permission_uuid.py
@@ -1,0 +1,77 @@
+"""Regression test for permission_dependency UUID coercion.
+
+The JWT carries the user id as a string. `User.id` is a SQLAlchemy `Uuid`
+column whose bind processor requires a `uuid.UUID` object. PostgreSQL tolerates
+the string via the driver, but SQLite raises
+``AttributeError: 'str' object has no attribute 'hex'``. `permission_dependency`
+must coerce the string to `uuid.UUID` before querying so both dialects work.
+"""
+import asyncio
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from starlette.requests import Request
+
+from database_utils.database import Base
+from database_utils.models.auth import Company, Role, Tier, User
+from database_utils.utils.jwt_utils import create_access_token
+from database_utils.utils.permission_utils import require_permission
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_admin_user(db):
+    tier = Tier(id=uuid.uuid4(), name="T", price=1, billing_cycle="MONTHLY")
+    db.add(tier)
+    db.commit()
+    company = Company(id=uuid.uuid4(), name="C", email="c@e.com", tier_id=tier.id)
+    db.add(company)
+    db.commit()
+    user = User(
+        id=uuid.uuid4(),
+        name="U",
+        email="u@e.com",
+        age=30,
+        password_hash="x",
+        company_id=company.id,
+        is_super_admin=True,
+    )
+    role = Role(id=uuid.uuid4(), name="ADMIN", company_id=company.id)
+    user.roles.append(role)
+    db.add_all([user, role])
+    db.commit()
+    return user
+
+
+def _request_with_token(token: str) -> Request:
+    scope = {
+        "type": "http",
+        "headers": [(b"authorization", f"Bearer {token}".encode())],
+        "path": "/",
+        "method": "GET",
+    }
+    return Request(scope)
+
+
+def test_permission_dependency_coerces_string_id(db):
+    """A string-id JWT resolves to the user under SQLite (no 'hex' crash)."""
+    user = _make_admin_user(db)
+    token = create_access_token(user)  # payload id is a string
+
+    dependency = require_permission("products.read", lambda: db)
+    resolved = asyncio.run(dependency(_request_with_token(token), db=db))
+
+    assert resolved.id == user.id

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,12 @@
+"""Smoke tests: the package and its models import without error."""
+
+
+def test_package_imports():
+    import database_utils  # noqa: F401
+
+
+def test_models_import():
+    from database_utils.models import auth, crm  # noqa: F401
+
+    assert hasattr(auth, "User")
+    assert hasattr(crm, "Client")


### PR DESCRIPTION
Composed release (develop → main).

## Changes
- **fix:** coerce JWT user id (string) to \`uuid.UUID\` in \`permission_dependency\` — Postgres tolerated the string; SQLite-based test suites crashed (\`'str' object has no attribute 'hex'\`). Now correct on both dialects. Regression test added.
- **ci:** add \`.github/workflows/ci.yml\` (pytest + ruff advisory) + smoke tests.
- **perf:** BuildKit pip cache mount in the local dev Dockerfile.
- version → 1.4.7.

No alembic migration in this release (no prod DB migration triggered).

Verified: local docker compose E2E green (24/24 frontend smoke; backend CRM endpoints 200; auth path validated against real Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)