### PR TITLE
Hotfix: revert Dockerfile cache mount (breaks Railway build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax=docker/dockerfile:1
-# Local development image for models-utils Alembic migrations.
+# Image for models-utils Alembic migrations.
 # Used by the docker-compose `migrate` one-shot service to bring the local
 # Postgres up to head before the backends start.
 # Production/dev DB migrations on Railway run via GitHub Actions, not this file.
+# Keep it portable — no BuildKit-only syntax (e.g. cache mounts).
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -13,12 +13,8 @@ RUN apt-get update \
 
 # Install the package (pulls SQLAlchemy, Alembic, psycopg2, etc.) plus the
 # working-tree source which carries the alembic/ migration scripts.
-# BuildKit cache mount: even when source changes bust this layer, pip reuses
-# the cached downloads/wheels (shared with backend-erp/auth-erp) instead of
-# re-fetching the whole dependency tree.
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install .
+RUN pip install --no-cache-dir .
 
 # alembic.ini lives at the repo root; DB_URL is injected by docker-compose.
 CMD ["alembic", "upgrade", "head"]


### PR DESCRIPTION
Hotfix: revert BuildKit cache-mount Dockerfile syntax that broke the Railway build (`--mount=type=cache ... missing an id argument`). Restores the plain-install Dockerfile that deployed successfully previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)