### PR TITLE
Security hotfixes: JWT expiry + SECRET_KEY fail-fast (SEC-1/SEC-2)

### DIFF
--- a/database_utils/utils/jwt_utils.py
+++ b/database_utils/utils/jwt_utils.py
@@ -11,10 +11,20 @@ from loguru import logger
 
 load_dotenv()
 
-# Load environment variables with defaults to avoid errors during import
-access_expire = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "114400"))  # 1 day in minutes
+# Load environment variables with defaults to avoid errors during import.
+# NOTE: the env var is ACCESS_TOKEN_EXPIRE (minutes) — every service .env sets it.
+# The old name ACCESS_TOKEN_EXPIRE_MINUTES was never set anywhere, so the 114400
+# default (~79 days) was silently always in effect.
+access_expire = int(os.getenv("ACCESS_TOKEN_EXPIRE", "1440"))  # 1 day in minutes
 refresh_expire = int(os.getenv("REFRESH_TOKEN_EXPIRE", "604800"))  # 7 days in seconds
-secret_key = os.getenv("SECRET_KEY", "default-secret-key-for-development")
+
+# Signing key. Fail fast in production rather than silently falling back to a
+# well-known string (which would allow token forgery). Dev/test keep a fallback.
+secret_key = os.getenv("SECRET_KEY")
+if not secret_key:
+    if os.getenv("ENVIRONMENT") == "production":
+        raise RuntimeError("SECRET_KEY environment variable must be set in production")
+    secret_key = "default-secret-key-for-development"
 
 ALGORITHM = "HS256"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.5.0
+version = 1.5.1
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)

--- a/tests/test_jwt_expiry.py
+++ b/tests/test_jwt_expiry.py
@@ -1,0 +1,49 @@
+"""Regression tests for JWT expiry/secret configuration (SEC-1, SEC-2).
+
+The access-token TTL must be read from ACCESS_TOKEN_EXPIRE (minutes), not the
+old ACCESS_TOKEN_EXPIRE_MINUTES that no environment ever set (which left the
+114400-minute ~79-day default silently in effect).
+"""
+import importlib
+import os
+
+import pytest
+
+
+def _reload_jwt(monkeypatch, **env):
+    for k in ("ACCESS_TOKEN_EXPIRE", "ACCESS_TOKEN_EXPIRE_MINUTES", "SECRET_KEY", "ENVIRONMENT"):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    import database_utils.utils.jwt_utils as jwt_utils
+    return importlib.reload(jwt_utils)
+
+
+def test_access_expire_reads_access_token_expire(monkeypatch):
+    m = _reload_jwt(monkeypatch, ACCESS_TOKEN_EXPIRE="1440", SECRET_KEY="x" * 32)
+    assert m.access_expire == 1440
+
+
+def test_access_expire_defaults_to_one_day_not_79(monkeypatch):
+    # No ACCESS_TOKEN_EXPIRE set -> must default to 1440 (1 day), never 114400.
+    m = _reload_jwt(monkeypatch, SECRET_KEY="x" * 32)
+    assert m.access_expire == 1440
+
+
+def test_missing_secret_raises_in_production(monkeypatch):
+    with pytest.raises(RuntimeError):
+        _reload_jwt(monkeypatch, ENVIRONMENT="production")
+
+
+def test_missing_secret_falls_back_outside_production(monkeypatch):
+    m = _reload_jwt(monkeypatch)  # no ENVIRONMENT, no SECRET_KEY
+    assert m.secret_key == "default-secret-key-for-development"
+
+
+@pytest.fixture(autouse=True)
+def _restore(monkeypatch):
+    yield
+    # Ensure a valid module state for any later imports in the session.
+    monkeypatch.setenv("SECRET_KEY", "x" * 32)
+    import database_utils.utils.jwt_utils as jwt_utils
+    importlib.reload(jwt_utils)


### PR DESCRIPTION
Wave 0 security hotfixes.

- SEC-1: read ACCESS_TOKEN_EXPIRE (was ACCESS_TOKEN_EXPIRE_MINUTES, never set → ~79-day tokens). Default 1440 (1 day).
- SEC-2: SECRET_KEY fails fast in production instead of falling back to a well-known signing key.
- +tests, version 1.5.1. No schema change (migrate.yml will not fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)