### PR TITLE
Wave 1: workflow engine correctness (WF-1/2/3)

### DIFF
--- a/database_utils/utils/workflow_engine.py
+++ b/database_utils/utils/workflow_engine.py
@@ -34,6 +34,11 @@ from database_utils.utils.timezone_utils import now_gt
 _workflow_execution_depth = contextvars.ContextVar('workflow_depth', default=0)
 MAX_WORKFLOW_DEPTH = 3
 
+# Strong references to fire-and-forget workflow tasks. The event loop only keeps
+# a weak reference to a Task, so without this a scheduled workflow execution can
+# be garbage-collected mid-run (WF-3). Tasks discard themselves on completion.
+_background_tasks: set[asyncio.Task] = set()
+
 # Map resource types to their SQLAlchemy model classes
 _MODEL_MAP = None
 
@@ -112,7 +117,7 @@ async def check_workflow_triggers(
         })
 
         for workflow in matched:
-            asyncio.create_task(
+            task = asyncio.create_task(
                 _execute_workflow_async(
                     workflow_id=workflow.id,
                     trigger_event=trigger_event,
@@ -120,6 +125,8 @@ async def check_workflow_triggers(
                     depth=depth,
                 )
             )
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
 
     except Exception as e:
         logger.error(f"Error checking workflow triggers: {e}")
@@ -150,8 +157,14 @@ def find_matching_workflows(
         .all()
     )
 
+    # The filter join on WorkflowTrigger fans out one row per matching trigger,
+    # so `workflows` can contain the same Workflow multiple times. Dedupe by id
+    # so a workflow with >1 matching trigger executes exactly once (WF-2).
     matched = []
+    seen: set = set()
     for workflow in workflows:
+        if workflow.id in seen:
+            continue
         for trigger in workflow.triggers:
             if (
                 trigger.resource_type == resource_type
@@ -159,6 +172,7 @@ def find_matching_workflows(
                 and _matches_field_conditions(trigger.field_conditions, before_data, after_data)
             ):
                 matched.append(workflow)
+                seen.add(workflow.id)
                 break
 
     return matched
@@ -189,14 +203,20 @@ def _matches_field_conditions(
         return True
 
     elif operator == "changed_to":
-        if after_data:
-            return str(after_data.get(field)) == str(value)
-        return False
+        # True only on the transition INTO `value` — the field must not have
+        # already equalled `value` before (WF-1). Missing before_data (e.g. on
+        # CREATE) counts as "did not equal it before".
+        if not after_data:
+            return False
+        before_val = str(before_data.get(field)) if before_data else None
+        return before_val != str(value) and str(after_data.get(field)) == str(value)
 
     elif operator == "changed_from":
-        if before_data:
-            return str(before_data.get(field)) == str(value)
-        return False
+        # True only on the transition AWAY from `value`.
+        if not before_data:
+            return False
+        after_val = str(after_data.get(field)) if after_data else None
+        return str(before_data.get(field)) == str(value) and after_val != str(value)
 
     elif operator == "equals":
         if after_data:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.5.1
+version = 1.5.2
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -1,0 +1,67 @@
+"""Unit tests for workflow trigger-condition matching (WF-1).
+
+Focus: `changed_to` / `changed_from` must match only on an actual transition,
+not on every subsequent update while the field still holds the target value.
+"""
+from database_utils.utils.workflow_engine import _matches_field_conditions
+
+
+def cond(field="status", operator="changed_to", value="CANCELLED"):
+    return {"field": field, "operator": operator, "value": value}
+
+
+def test_none_conditions_match_any():
+    assert _matches_field_conditions(None, {"status": "A"}, {"status": "B"}) is True
+
+
+def test_changed_to_fires_on_transition():
+    assert _matches_field_conditions(
+        cond(), {"status": "ACTIVE"}, {"status": "CANCELLED"}
+    ) is True
+
+
+def test_changed_to_does_not_refire_when_already_equal():
+    # status was already CANCELLED before -> editing an unrelated field must NOT fire.
+    assert _matches_field_conditions(
+        cond(), {"status": "CANCELLED"}, {"status": "CANCELLED"}
+    ) is False
+
+
+def test_changed_to_on_create_with_no_before_fires_if_equal():
+    assert _matches_field_conditions(cond(), None, {"status": "CANCELLED"}) is True
+
+
+def test_changed_to_false_when_after_not_equal():
+    assert _matches_field_conditions(
+        cond(), {"status": "ACTIVE"}, {"status": "PAUSED"}
+    ) is False
+
+
+def test_changed_from_fires_on_transition_away():
+    assert _matches_field_conditions(
+        cond(operator="changed_from", value="ACTIVE"),
+        {"status": "ACTIVE"}, {"status": "CANCELLED"},
+    ) is True
+
+
+def test_changed_from_does_not_fire_when_still_equal():
+    assert _matches_field_conditions(
+        cond(operator="changed_from", value="ACTIVE"),
+        {"status": "ACTIVE"}, {"status": "ACTIVE"},
+    ) is False
+
+
+def test_changed_operator_detects_any_change():
+    assert _matches_field_conditions(
+        cond(operator="changed"), {"status": "A"}, {"status": "B"}
+    ) is True
+    assert _matches_field_conditions(
+        cond(operator="changed"), {"status": "A"}, {"status": "A"}
+    ) is False
+
+
+def test_equals_is_static_state_check():
+    assert _matches_field_conditions(
+        cond(operator="equals", value="CANCELLED"),
+        {"status": "CANCELLED"}, {"status": "CANCELLED"},
+    ) is True


### PR DESCRIPTION
Transition operators, multi-trigger dedupe, task GC refs + first workflow_engine tests. No schema change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)