### PR TITLE
Wave 2: tenant + hot-path indexes; client-delete cascade fix (PERF-1, DATA-1)

### DIFF
--- a/alembic/versions/a1f2b3c4d5e6_add_tenant_indexes.py
+++ b/alembic/versions/a1f2b3c4d5e6_add_tenant_indexes.py
@@ -1,0 +1,62 @@
+"""add tenant (company_id) and hot-path indexes (PERF-1)
+
+Additive only: creates btree indexes on the multi-tenant filter column
+(company_id) across every tenant-scoped table, plus two composite hot-path
+indexes. Uses CREATE INDEX IF NOT EXISTS / DROP INDEX IF EXISTS so the
+migration is idempotent and safe to re-run.
+
+Revision ID: a1f2b3c4d5e6
+Revises: 5cc0e3f33187
+Create Date: 2026-07-04
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1f2b3c4d5e6"
+down_revision = "5cc0e3f33187"
+branch_labels = None
+depends_on = None
+
+
+# (index_name, quoted_table, column_list) for the plain company_id indexes.
+_COMPANY_ID_INDEXES = [
+    ("ix_client_company_id", '"client"', "company_id"),
+    ("ix_product_company_id", '"product"', "company_id"),
+    ("ix_recurring_order_company_id", '"recurring_order"', "company_id"),
+    ("ix_order_company_id", '"order"', "company_id"),
+    ("ix_invoice_company_id", '"invoice"', "company_id"),
+    ("ix_custom_field_definition_company_id", '"custom_field_definition"', "company_id"),
+    ("ix_task_state_company_id", '"task_state"', "company_id"),
+    ("ix_task_company_id", '"task"', "company_id"),
+    ("ix_task_template_company_id", '"task_template"', "company_id"),
+    ("ix_integration_company_id", '"integration"', "company_id"),
+    ("ix_workflow_company_id", '"workflow"', "company_id"),
+    ("ix_notification_company_id", '"notification"', "company_id"),
+    ("ix_user_invitation_company_id", '"user_invitation"', "company_id"),
+    ("ix_payment_method_company_id", '"payment_method"', "company_id"),
+    ("ix_tier_change_request_company_id", '"tier_change_request"', "company_id"),
+]
+
+# Composite / partial hot-path indexes.
+_COMPOSITE_INDEXES = [
+    # cron "due recurring orders" scan filters status (+ company_id)
+    ("ix_recurring_order_status_company", 'CREATE INDEX IF NOT EXISTS ix_recurring_order_status_company ON "recurring_order" (status, company_id)'),
+    # "overdue / delayed-unpaid" dashboard query
+    ("ix_order_company_overdue", "CREATE INDEX IF NOT EXISTS ix_order_company_overdue ON \"order\" (company_id, due_date) WHERE paid = false AND status = 'ACTIVE'"),
+]
+
+_ALL_INDEX_NAMES = [name for name, _, _ in _COMPANY_ID_INDEXES] + [name for name, _ in _COMPOSITE_INDEXES]
+
+
+def upgrade() -> None:
+    for name, table, col in _COMPANY_ID_INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {name} ON {table} ({col})")
+    for _name, ddl in _COMPOSITE_INDEXES:
+        op.execute(ddl)
+
+
+def downgrade() -> None:
+    for name in _ALL_INDEX_NAMES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")

--- a/database_utils/models/auth.py
+++ b/database_utils/models/auth.py
@@ -160,7 +160,7 @@ class Notification(Base):
     pending_role_ids: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
     # --- [END] Possible User data: Add User Fields ---
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     user_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=True)
 
     # Relationships
@@ -198,7 +198,7 @@ class UserInvitation(Base):
     name = Column(String, nullable=True)  # Optional pre-fill by admin
 
     # Foreign keys
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     invited_by_user_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
     accepted_user_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
 
@@ -291,7 +291,7 @@ class PaymentMethod(Base):
     is_active = Column(Boolean, default=True, nullable=False)
 
     # Foreign keys
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Stripe integration
     stripe_payment_method_id = Column(String, nullable=True, unique=True)
@@ -354,7 +354,7 @@ class TierChangeRequest(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, default=now_gt)
 
     # Who is requesting and for which company
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     requested_by_user_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
 
     # Tier details

--- a/database_utils/models/crm.py
+++ b/database_utils/models/crm.py
@@ -78,14 +78,18 @@ class Client(Base):
     contact = Column(String, nullable=True)
     observations = Column(String, nullable=True)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     advisor_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
 
     # Relationships
     company = relationship("Company", back_populates="clients")
     advisor = relationship("User", back_populates="clients")
-    orders = relationship("Order", back_populates="client", cascade="all, delete-orphan")
-    recurring_orders = relationship("RecurringOrder", back_populates="client", cascade="all, delete-orphan")
+    # DATA-1: NO delete-orphan cascade on orders/recurring_orders. The FK is
+    # ondelete=SET NULL by design (an order/recurring order outlives its client),
+    # and delete_client blocks deletion while orders exist. A delete-orphan cascade
+    # here would silently destroy a client's entire order + invoice history.
+    orders = relationship("Order", back_populates="client")
+    recurring_orders = relationship("RecurringOrder", back_populates="client")
     custom_field_values = relationship("ClientCustomFieldValue", back_populates="client", cascade="all, delete-orphan")
 
 
@@ -99,7 +103,7 @@ class Product(Base):
     description = Column(String, nullable=False)
     stock = Column(Integer, nullable=False)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Relationships
     company = relationship("Company", back_populates="products")
@@ -118,13 +122,18 @@ class RecurringOrder(Base):
     status = Column(Enum(RecurringOrderStatus), nullable=False, default=RecurringOrderStatus.ACTIVE, server_default='ACTIVE')
 
     client_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("client.id", ondelete="SET NULL"), nullable=True)
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Relationships
     client = relationship("Client", back_populates="recurring_orders")
     company = relationship("Company", back_populates="recurring_orders")
     template_items = relationship("RecurringOrderItem", back_populates="recurring_order", cascade="all, delete-orphan")
     generated_orders = relationship("Order", back_populates="recurring_order")
+
+    # PERF-1: the cron "due recurring orders" scan filters by status (+ company_id).
+    __table_args__ = (
+        Index("ix_recurring_order_status_company", "status", "company_id"),
+    )
 
 
 class RecurringOrderItem(Base):
@@ -153,7 +162,7 @@ class Order(Base):
     paid = Column(Boolean, nullable=False)
     status = Column(Enum(OrderStatus), nullable=False, default=OrderStatus.ACTIVE, server_default='ACTIVE')
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     client_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("client.id", ondelete="SET NULL"), nullable=True)
     recurring_order_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("recurring_order.id", ondelete="SET NULL"), nullable=True)
 
@@ -173,6 +182,14 @@ class Order(Base):
             "due_date",
             unique=True,
             postgresql_where=text("status != 'CANCELLED' AND recurring_order_id IS NOT NULL"),
+        ),
+        # PERF-1: serves the hot "overdue / delayed-unpaid" dashboard query
+        # (company_id + paid=false + status=ACTIVE + due_date).
+        Index(
+            "ix_order_company_overdue",
+            "company_id",
+            "due_date",
+            postgresql_where=text("paid = false AND status = 'ACTIVE'"),
         ),
     )
 
@@ -203,7 +220,7 @@ class Invoice(Base):
     details = Column(JSON, nullable=False)
     is_valid = Column(Boolean, nullable=False, default=True)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     order_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("order.id", ondelete="CASCADE"), nullable=False)
 
     # Relationships
@@ -223,7 +240,7 @@ class CustomFieldDefinition(Base):
     is_required = Column(Boolean, nullable=False, default=False)
     display_order = Column(Integer, nullable=False, default=0)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Relationships
     company = relationship("Company", back_populates="custom_field_definitions")
@@ -256,7 +273,7 @@ class TaskState(Base):
     color = Column(Enum(TaskStateColor), nullable=False, default=TaskStateColor.GRAY, server_default='GRAY')
     position = Column(Integer, nullable=False, default=0)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # Relationships
     company = relationship("Company", back_populates="task_states")
@@ -277,7 +294,7 @@ class Task(Base):
     linked_object_type = Column(Enum(TaskLinkedObjectType), nullable=True)
     linked_object_id = Column(Uuid, nullable=True)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     task_state_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("task_state.id", ondelete="RESTRICT"), nullable=False)
     created_by: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
 
@@ -301,7 +318,7 @@ class TaskTemplate(Base):
     default_assignee_ids = Column(JSON, nullable=True)
     linked_object_type = Column(Enum(TaskLinkedObjectType), nullable=True)
 
-    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False)
+    company_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
 
     # Relationships
@@ -333,7 +350,7 @@ class Integration(Base):
     # BASIC_AUTH:    {"username": "admin", "password": "..."}
 
     company_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False
+        Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Relationships

--- a/database_utils/models/workflow.py
+++ b/database_utils/models/workflow.py
@@ -47,7 +47,7 @@ class Workflow(Base):
     is_active = Column(Boolean, nullable=False, default=True)
 
     company_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False
+        Uuid, ForeignKey("company.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Relationships

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.5.2
+version = 1.6.0
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)


### PR DESCRIPTION
Additive idempotent index migration (company_id across all tenant tables + 2 composites) and removal of the client delete-orphan cascade. Migration verified via offline PG SQL + single-head check; no data-validating constraints. 🤖 Generated with [Claude Code](https://claude.com/claude-code)