### PR TITLE
Wave 3: SSRF guard on workflow HTTP step (SEC-6)

### DIFF
--- a/database_utils/utils/ssrf.py
+++ b/database_utils/utils/ssrf.py
@@ -1,0 +1,58 @@
+"""Shared SSRF guard for outbound HTTP made on behalf of stored Integrations.
+
+Both the interactive "test integration" endpoint (backend-erp) and the automatic
+workflow HTTP_REQUEST step (workflow_engine) send requests to an operator-supplied
+`base_url` with stored credentials attached. Without validation that is an SSRF
+primitive (cloud metadata 169.254.169.254, localhost, internal services) plus an
+exfiltration channel. This module centralises the blocklist so every outbound
+path uses the same guard (SEC-6).
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class SSRFValidationError(Exception):
+    """Raised when a URL resolves to a blocked / private / internal address."""
+
+
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+_BLOCKED_KEYWORDS = ("localhost", "metadata", "internal")
+
+
+def validate_url_no_ssrf(url: str) -> str:
+    """Validate that `url`'s host is public and return the resolved IP.
+
+    Rejects hostnames containing internal keywords and any host that resolves to a
+    private/loopback/link-local address (checking ALL A/AAAA records to cover
+    round-robin DNS). Returns the first validated IP so the caller may pin to it.
+    Raises SSRFValidationError on any violation.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFValidationError("Invalid URL: missing hostname")
+    if any(kw in hostname.lower() for kw in _BLOCKED_KEYWORDS):
+        raise SSRFValidationError("Requests to internal addresses are not allowed")
+    try:
+        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise SSRFValidationError("Could not resolve hostname") from exc
+    if not infos:
+        raise SSRFValidationError("Could not resolve hostname")
+    for *_rest, sockaddr in (info[:] for info in infos):
+        resolved_ip = ipaddress.ip_address(sockaddr[0])
+        if any(resolved_ip in net for net in _PRIVATE_NETWORKS):
+            raise SSRFValidationError("Requests to private network addresses are not allowed")
+    return infos[0][4][0]

--- a/database_utils/utils/workflow_engine.py
+++ b/database_utils/utils/workflow_engine.py
@@ -545,6 +545,14 @@ def _execute_http_request(
     path = config.get("path", "")
     url = integration.base_url.rstrip("/") + path
 
+    # SEC-6: block SSRF to internal / cloud-metadata / private addresses BEFORE
+    # attaching stored credentials or making any request.
+    from database_utils.utils.ssrf import validate_url_no_ssrf, SSRFValidationError
+    try:
+        validate_url_no_ssrf(url)
+    except SSRFValidationError as e:
+        raise ValueError(f"HTTP_REQUEST step blocked (SSRF guard): {e}")
+
     # Build headers: start with configured extra headers, then inject auth
     headers: dict = dict(config.get("headers", {}))
     creds: dict = integration.credentials or {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = database-utils
-version = 1.6.0
+version = 1.6.1
 author = Ricardo Pellecer
 author_email = you@example.com
 description = Shared SQLAlchemy models, migrations, and dependencies for FastAPI services with comprehensive audit logging (UUID primary keys)

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,0 +1,28 @@
+"""Tests for the shared SSRF guard (SEC-6). Uses numeric hosts so no DNS is needed."""
+import pytest
+
+from database_utils.utils.ssrf import validate_url_no_ssrf, SSRFValidationError
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8080/x",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://something.internal/",
+        "http://127.0.0.1/",
+        "http://10.0.0.5/admin",
+        "http://192.168.1.1/",
+        "http://172.16.5.4/",
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "",
+        "not-a-url",
+    ],
+)
+def test_blocked(url):
+    with pytest.raises(SSRFValidationError):
+        validate_url_no_ssrf(url)
+
+
+def test_public_ip_allowed():
+    assert validate_url_no_ssrf("http://8.8.8.8/") == "8.8.8.8"


### PR DESCRIPTION
Shared SSRF validator blocking internal/metadata/private targets before creds are attached. +tests. No schema change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)